### PR TITLE
Add CI support for Penglai-Opensbi-TVM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+# This is a basic workflow to help you get started with Actions
+
+name: build
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    # using: 'docker'
+    runs-on: ubuntu-latest
+    name: Build penglai enclave
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Build Penglai monitor (based on OpenSBI).
+        id: build
+        uses: jxq96/action-penglai-opensbi-build@v1
+      # Runs a single command using the runners shell
+
+      # Runs a set of commands using the runners shell
+      # - name: Run a multi-line script
+      #   run: |
+      #     echo Add other actions to build,
+      #     echo test, and deploy your project.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    # using: 'docker'
+    runs-on: ubuntu-latest
+    name: Build and run penglai enclave
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Build and test Penglai monitor (based on OpenSBI).
+        id: build_run
+        uses: jxq96/action-penglai-opensbi-build-and-test@v1
+      # Runs a single command using the runners shell
+
+      # Runs a set of commands using the runners shell
+      # - name: Run a multi-line script
+      #   run: |
+      #     echo Add other actions to build,
+      #     echo test, and deploy your project.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Build](https://github.com/Penglai-Enclave/Penglai-Opensbi-TVM/actions/workflows/build.yml/badge.svg)](https://github.com/Penglai-Enclave/Penglai-Opensbi-TVM/actions/workflows/build.yml)
+[![CI](https://github.com/Penglai-Enclave/Penglai-Opensbi-TVM/actions/workflows/ci.yml/badge.svg)](https://github.com/Penglai-Enclave/Penglai-Opensbi-TVM/actions/workflows/ci.yml)
+[![License: Mulan](https://img.shields.io/badge/license-Mulan-brightgreen.svg)](https://license.coscl.org.cn/MulanPSL)
+
 RISC-V Open Source Supervisor Binary Interface (OpenSBI)
 ========================================================
 


### PR DESCRIPTION
I added build test and CI support for build monitor only with Image and rootfs binary, which is beneficial for the devlopment of Penglai monitor (based on OpenSBI)